### PR TITLE
Add static Korean page and build script

### DIFF
--- a/kr/index.html
+++ b/kr/index.html
@@ -1,9 +1,9 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html><html lang="ko"><head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta name="description" content="">
         <meta name="author" content="">
-        <title id="page-title">Joon Ryul Lee - Resume</title>
+        <title id="page-title">이준렬 - 이력서</title>
         <link rel="icon" type="image/x-icon" href="/assets/img/favicon.ico">
         <!-- Font Awesome icons (free version)-->
         <script src="https://use.fontawesome.com/releases/v5.15.1/js/all.js" crossorigin="anonymous"></script>
@@ -93,10 +93,10 @@
         <!-- Navigation-->
         <nav class="navbar navbar-expand-lg navbar-dark bg-primary fixed-top" id="sideNav">
             <a class="navbar-brand js-scroll-trigger" href="#page-top">
-                <span class="d-block d-lg-none" id="navbar-name">Lee Joon Ryul</span>
+                <span class="d-block d-lg-none" id="navbar-name">이준렬</span>
                 <span class="d-none d-lg-block" id="profile-image-container"><img class="img-fluid img-profile rounded-circle mx-auto mb-2" src="/assets/img/profile.jpg" alt=""></span>
             </a>
-            <a class="lang-toggle-top d-none d-lg-block" data-lang-link="alternate" href="/kr/"><i class="fas fa-globe mr-1"></i><span>한국어</span></a>
+            <a class="lang-toggle-top d-none d-lg-block" data-lang-link="alternate" href="/"><i class="fas fa-globe mr-1"></i><span>English</span></a>
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav">
@@ -107,7 +107,7 @@
                     <li class="nav-item"><a class="nav-link js-scroll-trigger" href="#skills">Skills</a></li>
                     <li class="nav-item"><a class="nav-link js-scroll-trigger" href="#interests">Interests</a></li>
                     <li class="nav-item"><a class="nav-link js-scroll-trigger" href="#extracurricular">Extra Curricular</a></li>
-                    <li class="nav-item d-lg-none mt-3 text-center"><a class="nav-link lang-toggle" data-lang-link="alternate" href="/kr/"><i class="fas fa-globe mr-1"></i><span>한국어</span></a></li>
+                    <li class="nav-item d-lg-none mt-3 text-center"><a class="nav-link lang-toggle" data-lang-link="alternate" href="/"><i class="fas fa-globe mr-1"></i><span>English</span></a></li>
                 </ul>
             </div>
         </nav>
@@ -117,19 +117,19 @@
             <section class="resume-section" id="about">
                 <div class="resume-section-content">
                     <h1 class="mb-0" id="main-name-heading">
-                        <span id="first-name">Joon Ryul (JR)</span>
-                        <span class="text-primary" id="last-name">Lee</span>
+                        <span id="first-name">이</span>
+                        <span class="text-primary" id="last-name">준렬</span>
                     </h1>
                     <div class="subheading mb-5" id="status">
                         <span id="status-info">U.S. Permanent Resident – No visa sponsorship required</span>
                     </div>
                     <div class="subheading mb-5" id="contact-info">
-                        <span id="phone-address">(010) 4511-3287</span>
+                        <span id="phone-address">(010) 4511-3287 · 서울시 구로구 신도림동 419-4</span>
                     						<p id="email-container"><a href="mailto:jrl1103@gmail.com" id="email-link">jrl1103@gmail.com</a></p>
                     </div>
                     <div class="lead mb-5" id="personal-statement">
-                    						<span id="statement-line1">Client Programmer - Games are developed collaboratively, not in isolation</span>
-                    						<br><span id="statement-line2">Prioritizing efficiency, usability, cooperation, and communication</span>
+                    						<span id="statement-line1">클라이언트 프로그래머 - 게임은 혼자가 아닌 함께 개발하는 것</span>
+                    						<br><span id="statement-line2">효율성, 편리성, 협동, 소통을 우선시하는 프로그래머</span>
 					</div>
                     <div class="social-icons" id="social-links">
                         <a class="social-icon" id="github-link" href="https://github.com/tyl3rdurden/HexGem"><i class="fab fa-github" id="github-icon"></i></a>
@@ -143,102 +143,102 @@
                     <h2 class="mb-5" id="experience-heading">Experience</h2>
                     <div class="d-flex flex-column flex-md-row justify-content-between mb-5" id="experience-nexon">
                         <div class="flex-grow-1">
-                            <h3 class="mb-0" id="job-title-nexon">Client Programmer &amp; Deputy Team Manager</h3>
-                            <div class="subheading mb-3" id="company-nexon">Nexon Games</div>
-                            <p id="project-nexon"><a href="https://bluearchive.nexon.com/home" id="project-link-nexon"><b id="project-title-nexon">Blue Archive</b></a> <span id="tech-stack-nexon">- Unity</span>
+                            <h3 class="mb-0" id="job-title-nexon">클라이언트 프로그래머</h3>
+                            <div class="subheading mb-3" id="company-nexon">넥슨게임즈</div>
+                            <p id="project-nexon"><a href="https://bluearchive.nexon.com/home" id="project-link-nexon"><b id="project-title-nexon">블루 아카이브</b></a> <span id="tech-stack-nexon">- Unity</span>
                             </p><ul id="ba-project-details">
                                 <li id="ba-1">Optimized runtime data handling by converting JSON to a binary format (MemoryPack), reducing memory usage by over 80% and improving CPU performance by 70%</li>
-                                <li id="ba-11">Implemented BattlePass</li>
+                                <li id="ba-11"></li>
                                 <li id="ba-2">Implemented seasonal content, including a railroad placement mini-game
                                     <ul>
                                         <li><a href="https://www.youtube.com/watch?v=73vNSgzlars" target="_blank">Video</a></li>
                                     </ul>
                                 </li>
-                                <li id="ba-3">Deputy Team Manager: mentored junior programmers, conducted code reviews, delegated tasks, and led regular check-ins</li>
+                                <li id="ba-3">Deputy Manager: mentored junior programmers, conducted code reviews, delegated tasks, and led regular check-ins.</li>
                             </ul>
                         </div>
-                        <div class="flex-shrink-0"><span class="text-primary" id="period-nexon">May 2024 - Present</span></div>
+                        <div class="flex-shrink-0"><span class="text-primary" id="period-nexon">2024년 5월 - 현재</span></div>
                     </div>
                     <div class="d-flex flex-column flex-md-row justify-content-between mb-5" id="experience-minlab">
                         <div class="flex-grow-1">
-                            <h3 class="mb-0" id="job-title-minlab">Client Programmer</h3>
-                            <div class="subheading mb-3" id="company-minlab">5minlab</div>
-                            <p id="project-openworld"><a href="https://www.youtube.com/watch?v=ErjxwLDKdkQ" id="project-link-openworld"><b id="project-title-openworld">Unreleased Open World Action RPG</b></a> <span id="tech-stack-openworld">- Unreal 5</span>
+                            <h3 class="mb-0" id="job-title-minlab">클라이언트 프로그래머</h3>
+                            <div class="subheading mb-3" id="company-minlab">5민랩</div>
+                            <p id="project-openworld"><a href="https://www.youtube.com/watch?v=ErjxwLDKdkQ" id="project-link-openworld"><b id="project-title-openworld">미출시 오픈월드 액션 RPG</b></a> <span id="tech-stack-openworld">- Unreal 5</span>
                                 </p><ul id="openworld-project-details">
-                                    <li id="openworld-gas">Implemented Gameplay Ability System (GAS)</li>
-                                    <li id="openworld-blueprint">Developed a system enabling designers to create various buffs using blueprints without programmer assistance</li>
+                                    <li id="openworld-gas">Gameplay Ability System (GAS) 적용</li>
+                                    <li id="openworld-blueprint">기획자가 블루프린트로 프로그래머 없이 다양한 버프들을 만들 수 있도록 시스템 구축</li>
                                 </ul>
                             <p></p>
-                            <p id="project-action-rpg"><b id="project-title-action-rpg">Unreleased Action RPG</b> <span id="tech-stack-action-rpg">- Unity</span>
+                            <p id="project-action-rpg"><b id="project-title-action-rpg">미출시 액션 RPG</b> <span id="tech-stack-action-rpg">- Unity</span>
                                 </p><ul id="action-rpg-project-details">
-                                    <li id="action-rpg-prototype">Led rapid prototyping as the sole programmer</li>
-                                    <li id="action-rpg-conversion">Converted a top-down action game to full 3D and implemented all systems from combat mechanics to UI components (inventory, etc.)</li>
+                                    <li id="action-rpg-prototype">단독 프로그래머로 빠른 프로토타이핑</li>
+                                    <li id="action-rpg-conversion">탑다운 액션 게임 베이스를 갖고 풀 3D 로 전환 및 액션(전투) 부터 UI (인벤토리 등) 모두 구현</li>
                                 </ul>
                             <p></p>
-                            <p id="project-dingcom"><b id="project-title-dingcom">Dinkum Mobile</b> <span id="tech-stack-dingcom">- Unity</span>
+                            <p id="project-dingcom"><b id="project-title-dingcom">딩컴 모바일</b> <span id="tech-stack-dingcom">- Unity</span>
                                 </p><ul id="dingcom-project-details">
-                                    <li id="dingcom-art-support">Provided technical support for the art team (character customization, animation, etc.)</li>
-                                    <li id="dingcom-combat">Designed and implemented the combat system</li>
-                                    <li id="dingcom-multiplayer">Used Mirror library for multiplayer functionality</li>
+                                    <li id="dingcom-art-support">아트팀 기술 지원 (캐릭터 커스터마이제이션, 애니메이션 등)</li>
+                                    <li id="dingcom-combat">전투 시스템 구현</li>
+                                    <li id="dingcom-multiplayer">미러 라이브러리 사용한 멀티플레이어 작업</li>
                                 </ul>
                             <p></p>
                         </div>
-                        <div class="flex-shrink-0"><span class="text-primary" id="period-minlab">May 2023 - May 2024</span></div>
+                        <div class="flex-shrink-0"><span class="text-primary" id="period-minlab">2023년 5월 - 2024년 5월</span></div>
                     </div>
                     <div class="d-flex flex-column flex-md-row justify-content-between mb-5" id="experience-wgames">
                         <div class="flex-grow-1">
-                            <h3 class="mb-0" id="job-title-wgames">Unity Client Programmer</h3>
-                            <div class="subheading mb-3" id="company-wgames">DoubleU Games</div>
-                            <p id="project-undead"><a href="https://play.google.com/store/apps/details?id=com.doubledown.undead.world.hero.afk.game&amp;hl=en&amp;gl=US" id="project-link-undead"><b id="project-title-undead">Undead World</b></a> <span id="tech-stack-undead">- Idle RPG Game - Android / iOS</span>
+                            <h3 class="mb-0" id="job-title-wgames">유니티 클라이언트 프로그래머</h3>
+                            <div class="subheading mb-3" id="company-wgames">더블유게임즈</div>
+                            <p id="project-undead"><a href="https://play.google.com/store/apps/details?id=com.doubledown.undead.world.hero.afk.game&amp;hl=en&amp;gl=US" id="project-link-undead"><b id="project-title-undead">Undead World</b></a> <span id="tech-stack-undead">- 방치형 RPG 게임 - Android / iOS</span>
                                 </p><ul id="undead-project-details">
-                                    <li id="undead-ui-content">Out-game UI/UX content development</li>
-                                    <li id="undead-build-system">Managed build system infrastructure (Jenkins)</li>
+                                    <li id="undead-ui-content">아웃게임 UI/컨텐츠 개발</li>
+                                    <li id="undead-build-system">빌드 시스템 관리 (젠킨스)</li>
                                 </ul>
                             <p></p>
                         </div>
-                        <div class="flex-shrink-0"><span class="text-primary" id="period-wgames">June 2022 - May 2023</span></div>
+                        <div class="flex-shrink-0"><span class="text-primary" id="period-wgames">2022년 6월 - 2023년 5월</span></div>
                     </div>
                     <div class="d-flex flex-column flex-md-row justify-content-between mb-5" id="experience-minlab-smash">
                         <div class="flex-grow-1">
-                            <h3 class="mb-0" id="job-title-minlab-smash">Unity Client Programmer</h3>
-                            <div class="subheading mb-3" id="company-minlab-smash">5minlab</div>
-                            <p id="project-smash"><a href="https://store.steampowered.com/app/1352080/SMASH_LEGENDS/" id="project-link-smash"><b id="project-title-smash">Smash Legends</b></a> <span id="tech-stack-smash">- PVP Battle Action Game - Steam / Android / iOS</span>
+                            <h3 class="mb-0" id="job-title-minlab-smash">유니티 클라이언트 프로그래머</h3>
+                            <div class="subheading mb-3" id="company-minlab-smash">5민랩</div>
+                            <p id="project-smash"><a href="https://store.steampowered.com/app/1352080/SMASH_LEGENDS/" id="project-link-smash"><b id="project-title-smash">스메시 레전드</b></a> <span id="tech-stack-smash">- PVP 대전 액션 게임 - Steam / Android / iOS</span>
                                 </p><ul id="smash-project-details">
-                                    <li id="smash-legacy-code">Refactored legacy code and reduced technical debt to facilitate easier feature additions</li>
-                                    <li id="smash-tool-dev">Created, improved, and maintained tools to enhance content development productivity (maps, game modes, characters, VFX)</li>
-                                    <li id="smash-content-dev">In-game content (new character) development</li>
+                                    <li id="smash-legacy-code">레거시 코드 / 기술 부채 코드 리뉴얼 및 새로운 기능 추가 하기 쉽게 개선</li>
+                                    <li id="smash-tool-dev">컨텐츠(맵, 모드, 캐릭터, VFX) 개발 생산성 향상을 위한 툴 제작/개선/유지보수</li>
+                                    <li id="smash-content-dev">인게임 컨텐츠 (신규 캐릭터) 개발</li>
                                 </ul>
                             <p></p>
                         </div>
-                        <div class="flex-shrink-0"><span class="text-primary" id="period-minlab-smash">May 2021 - June 2022</span></div>
+                        <div class="flex-shrink-0"><span class="text-primary" id="period-minlab-smash">2021년 5월 - 2022년 6월</span></div>
                     </div>
                     <div class="d-flex flex-column flex-md-row justify-content-between mb-5" id="experience-andromeda-hero60">
                         <div class="flex-grow-1">
-                            <h3 class="mb-0" id="job-title-andromeda-hero60">Unity Client Programmer</h3>
-                            <div class="subheading mb-3" id="company-andromeda-hero60">Andromeda Games</div>
-                    								<p id="project-hero60"><a href="https://play.google.com/store/apps/details?id=com.andromedagames.hero60&amp;hl=ko" id="project-link-hero60"><b id="project-title-hero60">60 Second Hero</b></a> <span id="tech-stack-hero60">- Android</span>
+                            <h3 class="mb-0" id="job-title-andromeda-hero60">유니티 클라이언트 프로그래머</h3>
+                            <div class="subheading mb-3" id="company-andromeda-hero60">안드로메다게임즈</div>
+                    								<p id="project-hero60"><a href="https://play.google.com/store/apps/details?id=com.andromedagames.hero60&amp;hl=ko" id="project-link-hero60"><b id="project-title-hero60">60초 용사 출시</b></a> <span id="tech-stack-hero60">- 안드로이드</span>
                     									</p><ul id="hero60-project-details">
-                    										<li id="hero60-dev-cycle">Worked on project from prototype to release, and major live-service updates for guild systems and raids</li>
-                    										<li id="hero60-unity-tools">Created Unity editor tools to streamline testing and development workflows</li>
-                    										<li id="hero60-excel-vba">Developed an integrated Excel+VBA solution that enabled efficient balancing by allowing team members to set up party combinations and calculate DPS based on character, equipment, skill, and set buff data tables without connecting to the game</li>
-                    										<li id="hero60-ui-role">UI/UX content development - Used NGUI</li>
+                    										<li id="hero60-dev-cycle">프로젝트 초기부터 출시까지 개발, 유지 보수 및 길드와 레이드 등의 대규모 업데이트 개발</li>
+                    										<li id="hero60-unity-tools">원활한 테스팅 및 개발을 위한 유니티 에디터 툴 제작</li>
+                    										<li id="hero60-excel-vba">엑셀 + VBA – 엑셀 시트들의 캐릭터, 장비, 스킬, 세트 버프 데이터 테이블들 토대로 게임에 매번 접속할 필요 없이 밸런싱이 가능토록 파티 조합을 쉽게 세팅하고 DPS 를 계산 할수 있는 통합 엑셀 시트 제작</li>
+                    										<li id="hero60-ui-role">주로 UI/UX 담당, 서버와 정보 교류 - NGUI 사용</li>
                     									</ul>
                     								<p></p>
                         </div>
-                        <div class="flex-shrink-0"><span class="text-primary" id="period-andromeda-hero60">May 2018 - February 2019</span></div>
+                        <div class="flex-shrink-0"><span class="text-primary" id="period-andromeda-hero60">2018년 5월 - 2019년 2월</span></div>
                     </div>
                     <div class="d-flex flex-column flex-md-row justify-content-between mb-5" id="experience-andromeda-billiards">
                         <div class="flex-grow-1">
-                            <h3 class="mb-0" id="job-title-andromeda-billiards">Unity Client Programmer</h3>
-                            <div class="subheading mb-3" id="company-andromeda-billiards">Andromeda Games</div>
-                    								<p id="project-billiards"><a href="https://play.google.com/store/apps/details?id=com.andromedagames.billiardsgod&amp;hl=ko" id="project-link-billiards"><b id="project-title-billiards">God of Billiards</b></a> <span id="tech-stack-billiards">- Android</span>
+                            <h3 class="mb-0" id="job-title-andromeda-billiards">유니티 클라이언트 프로그래머</h3>
+                            <div class="subheading mb-3" id="company-andromeda-billiards">안드로메다게임즈</div>
+                    								<p id="project-billiards"><a href="https://play.google.com/store/apps/details?id=com.andromedagames.billiardsgod&amp;hl=ko" id="project-link-billiards"><b id="project-title-billiards">당구의 신 출시</b></a> <span id="tech-stack-billiards">- 안드로이드</span>
                     									</p><ul id="billiards-project-details">
-                    										<li id="billiards-dev-cycle">Worked on project from prototype to release, and major live-service updates for character systems and guilds</li>
-                    										<li id="billiards-ui-role">UI/UX content development - Used NGUI</li>
+                    										<li id="billiards-dev-cycle">프로젝트 계획부터 출시까지 개발, 유지 보수 및 캐릭터와 길드 등의 대규모 업데이트 개발</li>
+                    										<li id="billiards-ui-role">주로 UI/UX 담당, 서버와 정보 교류 - NGUI 사용</li>
                     									</ul>
                     								<p></p>
                         </div>
-                        <div class="flex-shrink-0"><span class="text-primary" id="period-andromeda-billiards">February 2015 - May 2016</span></div>
+                        <div class="flex-shrink-0"><span class="text-primary" id="period-andromeda-billiards">2015년 2월 - 2016년 5월</span></div>
                     </div>
                 </div>
             </section>
@@ -250,7 +250,7 @@
                     <div class="d-flex flex-column flex-md-row justify-content-between mb-5" id="portfolio-item-hexgem">
                         <div class="flex-grow-1">
                             <h3 class="mb-0" id="portfolio-title-hexgem"><a href="https://github.com/tyl3rdurden/HexGem" id="portfolio-link-hexgem">HexGem</a></h3>
-                            <div id="portfolio-description-hexgem">Portfolio project of a classic simple brush style 3 match game</div>
+                            <div id="portfolio-description-hexgem">클래식하고 간단한 브러시 스타일의 3매치 게임 포트폴리오 프로젝트</div>
                             <p id="portfolio-content-hexgem"></p>
                             <img src="https://i.imgur.com/ZfUgPO0.gif" id="portfolio-image-hexgem">
                         </div>
@@ -344,7 +344,9 @@
             <section class="resume-section" id="interests">
                 <div class="resume-section-content">
                     <h2 class="mb-5" id="interests-heading">Interests</h2>
-                    <p id="interests-paragraph-1">I'm a game developer first but I enjoy spending my time experiencing various story telling mediums such as games, TV shows, movies, and anime. I love being part of the ride involving great story telling and the feeling of having my jaw drop and just sitting in awe after the credits roll is one of the greatest pleasures I can have. Just being able to truly enjoy and be part of the moment is something I really value and hope I can integrate in my games.</p>
+                    <p id="interests-paragraph-1">I'm a game developer first but I enjoy spending my time experiencing various story telling mediums such as games, TV shows, movies, and anime.
+                        I love being part of the ride involving great story telling and the feeling of having my jaw drop and just sitting in awe after the credits roll is one of
+                        the greatest pleasures I can have. Just being able to truly enjoy and be part of the moment is something I really value and hope I can integrate in my games.</p>
                     <p class="mb-0" id="interests-paragraph-2">I also enjoy spending too much time on reddit and enjoy anything from cat pictures to the latest programming advancements or discussions on the implementation of a game feature.</p>
                 </div>
             </section>
@@ -353,7 +355,9 @@
             <section class="resume-section" id="extracurricular">
                 <div class="resume-section-content">
                     <h2 class="mb-5" id="extracurricular-heading">Extra Curriculars</h2>
-                    <p id="extracurricular-paragraph">I've always been interested in story telling and the passion people have. Whether it be creating a work of art that can only come together through the passion of everyone involved or people being involved in an intense esports scene, the passion and fun they had was always something that inspired me. It has been over 10 years ago since I've captured those moments but these documentaries are something I'm still proud of and feel inspired by on rewatches.</p>
+                    <p id="extracurricular-paragraph">I've always been interested in story telling and the passion people have. Whether it be creating a work of art that can only come together through the passion
+                        of everyone involved or people being involved in an intense esports scene, the passion and fun they had was always something that inspired me. It has been over
+                        10 years ago since I've captured those moments but these documentaries are something I'm still proud of and feel inspired by on rewatches.</p>
                     <br>
                     <ul id="documentary-list" class="fa-ul mb-0">
                         <li id="documentary-item-1">

--- a/localization.json
+++ b/localization.json
@@ -1,5 +1,6 @@
 {
   "en": {
+    "page-title": "Joon Ryul Lee - Resume",
     "navbar-name": "Lee Joon Ryul",
     "first-name": "Joon Ryul (JR)",
     "last-name": "Lee",
@@ -109,6 +110,7 @@
     "extracurricular-paragraph": "I've always been interested in story telling and the passion people have. Whether it be creating a work of art that can only come together through the passion of everyone involved or people being involved in an intense esports scene, the passion and fun they had was always something that inspired me. It has been over 10 years ago since I've captured those moments but these documentaries are something I'm still proud of and feel inspired by on rewatches."
   },
   "ko": {
+    "page-title": "이준렬 - 이력서",
     "navbar-name": "이준렬",
     "first-name": "이",
     "last-name": "준렬",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "axios": "^1.9.0",
                 "bootstrap": "^5.3.6",
                 "browserslist": "4.16.5",
+                "cheerio": "^1.1.2",
                 "debug": "4.3.1",
                 "hosted-git-info": "2.8.9",
                 "lodash": "4.17.21",
@@ -286,6 +287,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+            "license": "ISC"
         },
         "node_modules/bootstrap": {
             "version": "5.3.6",
@@ -592,6 +599,48 @@
                 "is-regex": "^1.0.3"
             }
         },
+        "node_modules/cheerio": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+            "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+            "license": "MIT",
+            "dependencies": {
+                "cheerio-select": "^2.1.0",
+                "dom-serializer": "^2.0.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.2.2",
+                "encoding-sniffer": "^0.2.1",
+                "htmlparser2": "^10.0.0",
+                "parse5": "^7.3.0",
+                "parse5-htmlparser2-tree-adapter": "^7.1.0",
+                "parse5-parser-stream": "^7.1.2",
+                "undici": "^7.12.0",
+                "whatwg-mimetype": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=20.18.1"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+            }
+        },
+        "node_modules/cheerio-select": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+            "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-select": "^5.1.0",
+                "css-what": "^6.1.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
         "node_modules/chokidar": {
             "version": "3.4.3",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
@@ -849,6 +898,34 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/css-select": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+            "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-what": "^6.1.0",
+                "domhandler": "^5.0.2",
+                "domutils": "^3.0.1",
+                "nth-check": "^2.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/css-what": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+            "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">= 6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
         "node_modules/date-fns": {
             "version": "2.16.1",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
@@ -936,6 +1013,61 @@
             "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
             "integrity": "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ=="
         },
+        "node_modules/dom-serializer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/domelementtype": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/domhandler": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "domelementtype": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/domutils": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+            "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -997,6 +1129,31 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/encoding-sniffer": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+            "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+            "license": "MIT",
+            "dependencies": {
+                "iconv-lite": "^0.6.3",
+                "whatwg-encoding": "^3.1.1"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+            }
+        },
+        "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/engine.io": {
@@ -1087,6 +1244,18 @@
                 "utf-8-validate": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/error-ex": {
@@ -1452,6 +1621,37 @@
             "version": "2.8.9",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
             "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+        },
+        "node_modules/htmlparser2": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+            "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+            "funding": [
+                "https://github.com/fb55/htmlparser2?sponsor=1",
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.2.1",
+                "entities": "^6.0.0"
+            }
+        },
+        "node_modules/htmlparser2/node_modules/entities": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
         },
         "node_modules/http-errors": {
             "version": "1.7.3",
@@ -1849,6 +2049,18 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/nth-check": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+            "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/nth-check?sponsor=1"
+            }
+        },
         "node_modules/num2fraction": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
@@ -1943,6 +2155,55 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/parse5": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5-htmlparser2-tree-adapter": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+            "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+            "license": "MIT",
+            "dependencies": {
+                "domhandler": "^5.0.3",
+                "parse5": "^7.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5-parser-stream": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+            "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+            "license": "MIT",
+            "dependencies": {
+                "parse5": "^7.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5/node_modules/entities": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/parseurl": {
@@ -2325,8 +2586,7 @@
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "dev": true
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "node_modules/sass": {
             "version": "1.28.0",
@@ -3082,6 +3342,15 @@
                 "node": "*"
             }
         },
+        "node_modules/undici": {
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+            "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.18.1"
+            }
+        },
         "node_modules/undici-types": {
             "version": "6.21.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -3138,6 +3407,39 @@
             "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/whatwg-encoding": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+            "license": "MIT",
+            "dependencies": {
+                "iconv-lite": "0.6.3"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/which-module": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "name": "startbootstrap-resume",
     "version": "6.0.2",
     "scripts": {
-        "build": "npm run clean && npm run build:pug && npm run build:scss && npm run build:scripts && npm run build:assets",
+        "build": "npm run clean && npm run build:pug && npm run build:scss && npm run build:scripts && npm run build:assets && npm run build:locales",
+        "build:locales": "node scripts/build-localized-pages.js",
         "build:assets": "node scripts/build-assets.js",
         "build:pug": "node scripts/build-pug.js",
         "build:scripts": "node scripts/build-scripts.js",
@@ -39,6 +40,7 @@
         "axios": "^1.9.0",
         "bootstrap": "^5.3.6",
         "browserslist": "4.16.5",
+        "cheerio": "^1.1.2",
         "debug": "4.3.1",
         "hosted-git-info": "2.8.9",
         "lodash": "4.17.21",

--- a/scripts/build-localized-pages.js
+++ b/scripts/build-localized-pages.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+const path = require('path');
+const cheerio = require('cheerio');
+
+const localizationPath = path.join(__dirname, '..', 'localization.json');
+const templatePath = path.join(__dirname, '..', 'templates', 'index.template.html');
+
+const localization = JSON.parse(fs.readFileSync(localizationPath, 'utf8'));
+const templateHtml = fs.readFileSync(templatePath, 'utf8');
+
+const languages = {
+    en: {
+        output: path.join(__dirname, '..', 'index.html'),
+        altHref: '/kr/',
+        altLabel: '한국어'
+    },
+    ko: {
+        output: path.join(__dirname, '..', 'kr', 'index.html'),
+        altHref: '/',
+        altLabel: 'English'
+    }
+};
+
+const TEXT_ONLY_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON']);
+
+function applyLocalization(html, lang, strings, alternateConfig) {
+    const $ = cheerio.load(html, { decodeEntities: false });
+
+    $('html').attr('lang', lang);
+
+    Object.entries(strings).forEach(([key, value]) => {
+        const el = $(`#${key}`);
+        if (el.length === 0) {
+            return;
+        }
+
+        const tagName = (el.get(0).tagName || '').toUpperCase();
+        const hasChildren = el.children().length > 0;
+
+        if (tagName === 'A' || (!hasChildren && !TEXT_ONLY_TAGS.has(tagName))) {
+            el.text(value);
+
+            if (tagName === 'A') {
+                const href = el.attr('href') || '';
+                if (href.startsWith('mailto:')) {
+                    el.attr('href', `mailto:${value}`);
+                }
+            }
+        }
+    });
+
+    $('[data-lang-link="alternate"]').each((_, element) => {
+        const $link = $(element);
+        $link.attr('href', alternateConfig.altHref);
+        const label = $link.find('span').first();
+        if (label.length) {
+            label.text(alternateConfig.altLabel);
+        }
+    });
+
+    return $.html();
+}
+
+Object.entries(languages).forEach(([lang, config]) => {
+    const strings = localization[lang];
+
+    if (!strings) {
+        throw new Error(`Missing localization for language: ${lang}`);
+    }
+
+    const localizedHtml = applyLocalization(templateHtml, lang, strings, config);
+
+    fs.mkdirSync(path.dirname(config.output), { recursive: true });
+    fs.writeFileSync(config.output, localizedHtml);
+});

--- a/templates/index.template.html
+++ b/templates/index.template.html
@@ -1,17 +1,19 @@
-<!DOCTYPE html><html lang="en"><head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta name="description" content="">
-        <meta name="author" content="">
-        <title id="page-title">Joon Ryul Lee - Resume</title>
-        <link rel="icon" type="image/x-icon" href="/assets/img/favicon.ico">
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+        <meta name="description" content="" />
+        <meta name="author" content="" />
+        <title id="page-title">이준렬 - 이력서</title>
+        <link rel="icon" type="image/x-icon" href="/assets/img/favicon.ico" />
         <!-- Font Awesome icons (free version)-->
         <script src="https://use.fontawesome.com/releases/v5.15.1/js/all.js" crossorigin="anonymous"></script>
         <!-- Google fonts-->
-        <link href="https://fonts.googleapis.com/css?family=Saira+Extra+Condensed:500,700" rel="stylesheet" type="text/css">
-        <link href="https://fonts.googleapis.com/css?family=Muli:400,400i,800,800i" rel="stylesheet" type="text/css">
+        <link href="https://fonts.googleapis.com/css?family=Saira+Extra+Condensed:500,700" rel="stylesheet" type="text/css" />
+        <link href="https://fonts.googleapis.com/css?family=Muli:400,400i,800,800i" rel="stylesheet" type="text/css" />
         <!-- Core theme CSS (includes Bootstrap)-->
-        <link href="/css/styles.css" rel="stylesheet">
+        <link href="/css/styles.css" rel="stylesheet" />
 		<!-- DevIcon-->
 		<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/devicons/devicon@v2.9.0/devicon.min.css">
         <style>
@@ -93,10 +95,10 @@
         <!-- Navigation-->
         <nav class="navbar navbar-expand-lg navbar-dark bg-primary fixed-top" id="sideNav">
             <a class="navbar-brand js-scroll-trigger" href="#page-top">
-                <span class="d-block d-lg-none" id="navbar-name">Lee Joon Ryul</span>
-                <span class="d-none d-lg-block" id="profile-image-container"><img class="img-fluid img-profile rounded-circle mx-auto mb-2" src="/assets/img/profile.jpg" alt=""></span>
+                <span class="d-block d-lg-none" id="navbar-name">이준렬</span>
+                <span class="d-none d-lg-block" id="profile-image-container"><img class="img-fluid img-profile rounded-circle mx-auto mb-2" src="/assets/img/profile.jpg" alt="" /></span>
             </a>
-            <a class="lang-toggle-top d-none d-lg-block" data-lang-link="alternate" href="/kr/"><i class="fas fa-globe mr-1"></i><span>한국어</span></a>
+            <a class="lang-toggle-top d-none d-lg-block" data-lang-link="alternate" href="/"><i class="fas fa-globe mr-1"></i><span>한국어</span></a>
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav">
@@ -107,7 +109,7 @@
                     <li class="nav-item"><a class="nav-link js-scroll-trigger" href="#skills">Skills</a></li>
                     <li class="nav-item"><a class="nav-link js-scroll-trigger" href="#interests">Interests</a></li>
                     <li class="nav-item"><a class="nav-link js-scroll-trigger" href="#extracurricular">Extra Curricular</a></li>
-                    <li class="nav-item d-lg-none mt-3 text-center"><a class="nav-link lang-toggle" data-lang-link="alternate" href="/kr/"><i class="fas fa-globe mr-1"></i><span>한국어</span></a></li>
+                    <li class="nav-item d-lg-none mt-3 text-center"><a class="nav-link lang-toggle" data-lang-link="alternate" href="/"><i class="fas fa-globe mr-1"></i><span>한국어</span></a></li>
                 </ul>
             </div>
         </nav>
@@ -117,132 +119,132 @@
             <section class="resume-section" id="about">
                 <div class="resume-section-content">
                     <h1 class="mb-0" id="main-name-heading">
-                        <span id="first-name">Joon Ryul (JR)</span>
-                        <span class="text-primary" id="last-name">Lee</span>
+                        <span id="first-name">이</span>
+                        <span class="text-primary" id="last-name">준렬</span>
                     </h1>
                     <div class="subheading mb-5" id="status">
                         <span id="status-info">U.S. Permanent Resident – No visa sponsorship required</span>
                     </div>
                     <div class="subheading mb-5" id="contact-info">
-                        <span id="phone-address">(010) 4511-3287</span>
+                        <span id="phone-address">(010) 4511-3287 · 서울시 구로구 신도림동 419-4</span>
                     						<p id="email-container"><a href="mailto:jrl1103@gmail.com" id="email-link">jrl1103@gmail.com</a></p>
                     </div>
                     <div class="lead mb-5" id="personal-statement">
-                    						<span id="statement-line1">Client Programmer - Games are developed collaboratively, not in isolation</span>
-                    						<br><span id="statement-line2">Prioritizing efficiency, usability, cooperation, and communication</span>
+                    						<span id="statement-line1">클라이언트 프로그래머 - 게임은 혼자가 아닌 함께 개발하는 것</span>
+                    						<br><span id="statement-line2">효율성, 편리성, 협동, 소통을 우선시하는 프로그래머</span>
 					</div>
                     <div class="social-icons" id="social-links">
                         <a class="social-icon" id="github-link" href="https://github.com/tyl3rdurden/HexGem"><i class="fab fa-github" id="github-icon"></i></a>
                     </div>
                 </div>
             </section>
-            <hr class="m-0">
+            <hr class="m-0" />
             <!-- Experience-->
             <section class="resume-section" id="experience">
                 <div class="resume-section-content">
                     <h2 class="mb-5" id="experience-heading">Experience</h2>
                     <div class="d-flex flex-column flex-md-row justify-content-between mb-5" id="experience-nexon">
                         <div class="flex-grow-1">
-                            <h3 class="mb-0" id="job-title-nexon">Client Programmer &amp; Deputy Team Manager</h3>
-                            <div class="subheading mb-3" id="company-nexon">Nexon Games</div>
-                            <p id="project-nexon"><a href="https://bluearchive.nexon.com/home" id="project-link-nexon"><b id="project-title-nexon">Blue Archive</b></a> <span id="tech-stack-nexon">- Unity</span>
-                            </p><ul id="ba-project-details">
-                                <li id="ba-1">Optimized runtime data handling by converting JSON to a binary format (MemoryPack), reducing memory usage by over 80% and improving CPU performance by 70%</li>
-                                <li id="ba-11">Implemented BattlePass</li>
+                            <h3 class="mb-0" id="job-title-nexon">클라이언트 프로그래머</h3>
+                            <div class="subheading mb-3" id="company-nexon">넥슨게임즈</div>
+                            <p id="project-nexon"><a href="https://bluearchive.nexon.com/home" id="project-link-nexon"><b id="project-title-nexon">블루 아카이브</b></a> <span id="tech-stack-nexon">- Unity</span>
+                            <ul id="ba-project-details">
+                                <li id="ba-1"></li>
+                                <li id="ba-11"></li>
                                 <li id="ba-2">Implemented seasonal content, including a railroad placement mini-game
                                     <ul>
                                         <li><a href="https://www.youtube.com/watch?v=73vNSgzlars" target="_blank">Video</a></li>
                                     </ul>
                                 </li>
-                                <li id="ba-3">Deputy Team Manager: mentored junior programmers, conducted code reviews, delegated tasks, and led regular check-ins</li>
+                                <li id="ba-3"></li>
                             </ul>
                         </div>
-                        <div class="flex-shrink-0"><span class="text-primary" id="period-nexon">May 2024 - Present</span></div>
+                        <div class="flex-shrink-0"><span class="text-primary" id="period-nexon">May 2024 - 현재</span></div>
                     </div>
                     <div class="d-flex flex-column flex-md-row justify-content-between mb-5" id="experience-minlab">
                         <div class="flex-grow-1">
-                            <h3 class="mb-0" id="job-title-minlab">Client Programmer</h3>
-                            <div class="subheading mb-3" id="company-minlab">5minlab</div>
-                            <p id="project-openworld"><a href="https://www.youtube.com/watch?v=ErjxwLDKdkQ" id="project-link-openworld"><b id="project-title-openworld">Unreleased Open World Action RPG</b></a> <span id="tech-stack-openworld">- Unreal 5</span>
-                                </p><ul id="openworld-project-details">
-                                    <li id="openworld-gas">Implemented Gameplay Ability System (GAS)</li>
-                                    <li id="openworld-blueprint">Developed a system enabling designers to create various buffs using blueprints without programmer assistance</li>
+                            <h3 class="mb-0" id="job-title-minlab">클라이언트 프로그래머</h3>
+                            <div class="subheading mb-3" id="company-minlab">5민랩</div>
+                            <p id="project-openworld"><a href="https://www.youtube.com/watch?v=ErjxwLDKdkQ" id="project-link-openworld"><b id="project-title-openworld">미출시 오픈월드 액션 RPG</b></a> <span id="tech-stack-openworld">- Unreal 5</span>
+                                <ul id="openworld-project-details">
+                                    <li id="openworld-gas">Gameplay Ability System (GAS) 적용</li>
+                                    <li id="openworld-blueprint">기획자가 블루프린트로 프로그래머 없이 다양한 버프들을 만들 수 있도록 시스템 구축</li>
                                 </ul>
-                            <p></p>
-                            <p id="project-action-rpg"><b id="project-title-action-rpg">Unreleased Action RPG</b> <span id="tech-stack-action-rpg">- Unity</span>
-                                </p><ul id="action-rpg-project-details">
-                                    <li id="action-rpg-prototype">Led rapid prototyping as the sole programmer</li>
-                                    <li id="action-rpg-conversion">Converted a top-down action game to full 3D and implemented all systems from combat mechanics to UI components (inventory, etc.)</li>
+                            </p>
+                            <p id="project-action-rpg"><b id="project-title-action-rpg">미출시 액션 RPG</b> <span id="tech-stack-action-rpg">- Unity</span>
+                                <ul id="action-rpg-project-details">
+                                    <li id="action-rpg-prototype">단독 프로그래머로 빠른 프로토타이핑</li>
+                                    <li id="action-rpg-conversion">탑다운 액션 게임 베이스를 갖고 풀 3D 로 전환 및 액션(전투) 부터 UI (인벤토리 등) 모두 구현</li>
                                 </ul>
-                            <p></p>
-                            <p id="project-dingcom"><b id="project-title-dingcom">Dinkum Mobile</b> <span id="tech-stack-dingcom">- Unity</span>
-                                </p><ul id="dingcom-project-details">
-                                    <li id="dingcom-art-support">Provided technical support for the art team (character customization, animation, etc.)</li>
-                                    <li id="dingcom-combat">Designed and implemented the combat system</li>
-                                    <li id="dingcom-multiplayer">Used Mirror library for multiplayer functionality</li>
+                            </p>
+                            <p id="project-dingcom"><b id="project-title-dingcom">딩컴 모바일</b> <span id="tech-stack-dingcom">- Unity</span>
+                                <ul id="dingcom-project-details">
+                                    <li id="dingcom-art-support">아트팀 기술 지원 (캐릭터 커스터마이제이션, 애니메이션 등)</li>
+                                    <li id="dingcom-combat">전투 시스템 구현</li>
+                                    <li id="dingcom-multiplayer">미러 라이브러리 사용한 멀티플레이어 작업</li>
                                 </ul>
-                            <p></p>
+                            </p>
                         </div>
                         <div class="flex-shrink-0"><span class="text-primary" id="period-minlab">May 2023 - May 2024</span></div>
                     </div>
                     <div class="d-flex flex-column flex-md-row justify-content-between mb-5" id="experience-wgames">
                         <div class="flex-grow-1">
-                            <h3 class="mb-0" id="job-title-wgames">Unity Client Programmer</h3>
-                            <div class="subheading mb-3" id="company-wgames">DoubleU Games</div>
-                            <p id="project-undead"><a href="https://play.google.com/store/apps/details?id=com.doubledown.undead.world.hero.afk.game&amp;hl=en&amp;gl=US" id="project-link-undead"><b id="project-title-undead">Undead World</b></a> <span id="tech-stack-undead">- Idle RPG Game - Android / iOS</span>
-                                </p><ul id="undead-project-details">
-                                    <li id="undead-ui-content">Out-game UI/UX content development</li>
-                                    <li id="undead-build-system">Managed build system infrastructure (Jenkins)</li>
+                            <h3 class="mb-0" id="job-title-wgames">유니티 클라이언트 프로그래머</h3>
+                            <div class="subheading mb-3" id="company-wgames">더블유게임즈</div>
+                            <p id="project-undead"><a href="https://play.google.com/store/apps/details?id=com.doubledown.undead.world.hero.afk.game&hl=en&gl=US" id="project-link-undead"><b id="project-title-undead">Undead World</b></a> <span id="tech-stack-undead">- 방치형 RPG 게임 - Android / iOS</span>
+                                <ul id="undead-project-details">
+                                    <li id="undead-ui-content">아웃게임 UI/컨텐츠 개발</li>
+                                    <li id="undead-build-system">빌드 시스템 관리 (젠킨스)</li>
                                 </ul>
-                            <p></p>
+                            </p>
                         </div>
                         <div class="flex-shrink-0"><span class="text-primary" id="period-wgames">June 2022 - May 2023</span></div>
                     </div>
                     <div class="d-flex flex-column flex-md-row justify-content-between mb-5" id="experience-minlab-smash">
                         <div class="flex-grow-1">
-                            <h3 class="mb-0" id="job-title-minlab-smash">Unity Client Programmer</h3>
-                            <div class="subheading mb-3" id="company-minlab-smash">5minlab</div>
-                            <p id="project-smash"><a href="https://store.steampowered.com/app/1352080/SMASH_LEGENDS/" id="project-link-smash"><b id="project-title-smash">Smash Legends</b></a> <span id="tech-stack-smash">- PVP Battle Action Game - Steam / Android / iOS</span>
-                                </p><ul id="smash-project-details">
-                                    <li id="smash-legacy-code">Refactored legacy code and reduced technical debt to facilitate easier feature additions</li>
-                                    <li id="smash-tool-dev">Created, improved, and maintained tools to enhance content development productivity (maps, game modes, characters, VFX)</li>
-                                    <li id="smash-content-dev">In-game content (new character) development</li>
+                            <h3 class="mb-0" id="job-title-minlab-smash">유니티 클라이언트 프로그래머</h3>
+                            <div class="subheading mb-3" id="company-minlab-smash">5민랩</div>
+                            <p id="project-smash"><a href="https://store.steampowered.com/app/1352080/SMASH_LEGENDS/" id="project-link-smash"><b id="project-title-smash">스메시 레전드</b></a> <span id="tech-stack-smash">- PVP 대전 액션 게임 - Steam / Android / iOS</span>
+                                <ul id="smash-project-details">
+                                    <li id="smash-legacy-code">레거시 코드 / 기술 부채 코드 리뉴얼 및 새로운 기능 추가 하기 쉽게 개선</li>
+                                    <li id="smash-tool-dev">컨텐츠(맵, 모드, 캐릭터, VFX) 개발 생산성 향상을 위한 툴 제작/개선/유지보수</li>
+                                    <li id="smash-content-dev">인게임 컨텐츠 (신규 캐릭터) 개발</li>
                                 </ul>
-                            <p></p>
+                            </p>
                         </div>
                         <div class="flex-shrink-0"><span class="text-primary" id="period-minlab-smash">May 2021 - June 2022</span></div>
                     </div>
                     <div class="d-flex flex-column flex-md-row justify-content-between mb-5" id="experience-andromeda-hero60">
                         <div class="flex-grow-1">
-                            <h3 class="mb-0" id="job-title-andromeda-hero60">Unity Client Programmer</h3>
-                            <div class="subheading mb-3" id="company-andromeda-hero60">Andromeda Games</div>
-                    								<p id="project-hero60"><a href="https://play.google.com/store/apps/details?id=com.andromedagames.hero60&amp;hl=ko" id="project-link-hero60"><b id="project-title-hero60">60 Second Hero</b></a> <span id="tech-stack-hero60">- Android</span>
-                    									</p><ul id="hero60-project-details">
-                    										<li id="hero60-dev-cycle">Worked on project from prototype to release, and major live-service updates for guild systems and raids</li>
-                    										<li id="hero60-unity-tools">Created Unity editor tools to streamline testing and development workflows</li>
-                    										<li id="hero60-excel-vba">Developed an integrated Excel+VBA solution that enabled efficient balancing by allowing team members to set up party combinations and calculate DPS based on character, equipment, skill, and set buff data tables without connecting to the game</li>
-                    										<li id="hero60-ui-role">UI/UX content development - Used NGUI</li>
+                            <h3 class="mb-0" id="job-title-andromeda-hero60">유니티 클라이언트 프로그래머</h3>
+                            <div class="subheading mb-3" id="company-andromeda-hero60">안드로메다게임즈</div>
+                    								<p id="project-hero60"><a href="https://play.google.com/store/apps/details?id=com.andromedagames.hero60&hl=ko" id="project-link-hero60"><b id="project-title-hero60">60초 용사 출시</b></a> <span id="tech-stack-hero60">- 안드로이드</span>
+                    									<ul id="hero60-project-details">
+                    										<li id="hero60-dev-cycle">프로젝트 초기부터 출시까지 개발, 유지 보수 및 길드와 레이드 등의 대규모 업데이트 개발</li>
+                    										<li id="hero60-unity-tools">원활한 테스팅 및 개발을 위한 유니티 에디터 툴 제작</li>
+                    										<li id="hero60-excel-vba">엑셀 + VBA – 엑셀 시트들의 캐릭터, 장비, 스킬, 세트 버프 데이터 테이블들 토대로 게임에 매번 접속할 필요 없이 밸런싱이 가능토록 파티 조합을 쉽게 세팅하고 DPS 를 계산 할수 있는 통합 엑셀 시트 제작</li>
+                    										<li id="hero60-ui-role">주로 UI/UX 담당, 서버와 정보 교류 - NGUI 사용</li>
                     									</ul>
-                    								<p></p>
+                    								</p>
                         </div>
                         <div class="flex-shrink-0"><span class="text-primary" id="period-andromeda-hero60">May 2018 - February 2019</span></div>
                     </div>
                     <div class="d-flex flex-column flex-md-row justify-content-between mb-5" id="experience-andromeda-billiards">
                         <div class="flex-grow-1">
-                            <h3 class="mb-0" id="job-title-andromeda-billiards">Unity Client Programmer</h3>
-                            <div class="subheading mb-3" id="company-andromeda-billiards">Andromeda Games</div>
-                    								<p id="project-billiards"><a href="https://play.google.com/store/apps/details?id=com.andromedagames.billiardsgod&amp;hl=ko" id="project-link-billiards"><b id="project-title-billiards">God of Billiards</b></a> <span id="tech-stack-billiards">- Android</span>
-                    									</p><ul id="billiards-project-details">
-                    										<li id="billiards-dev-cycle">Worked on project from prototype to release, and major live-service updates for character systems and guilds</li>
-                    										<li id="billiards-ui-role">UI/UX content development - Used NGUI</li>
+                            <h3 class="mb-0" id="job-title-andromeda-billiards">유니티 클라이언트 프로그래머</h3>
+                            <div class="subheading mb-3" id="company-andromeda-billiards">안드로메다게임즈</div>
+                    								<p id="project-billiards"><a href="https://play.google.com/store/apps/details?id=com.andromedagames.billiardsgod&hl=ko" id="project-link-billiards"><b id="project-title-billiards">당구의 신 출시</b></a> <span id="tech-stack-billiards">- 안드로이드</span>
+                    									<ul id="billiards-project-details">
+                    										<li id="billiards-dev-cycle">프로젝트 계획부터 출시까지 개발, 유지 보수 및 캐릭터와 길드 등의 대규모 업데이트 개발</li>
+                    										<li id="billiards-ui-role">주로 UI/UX 담당, 서버와 정보 교류</li>
                     									</ul>
-                    								<p></p>
+                    								</p>
                         </div>
                         <div class="flex-shrink-0"><span class="text-primary" id="period-andromeda-billiards">February 2015 - May 2016</span></div>
                     </div>
                 </div>
             </section>
-            <hr class="m-0">
+            <hr class="m-0" />
             <!-- Portfolio-->
             <section class="resume-section" id="portfolio">
                 <div class="resume-section-content">
@@ -252,12 +254,12 @@
                             <h3 class="mb-0" id="portfolio-title-hexgem"><a href="https://github.com/tyl3rdurden/HexGem" id="portfolio-link-hexgem">HexGem</a></h3>
                             <div id="portfolio-description-hexgem">Portfolio project of a classic simple brush style 3 match game</div>
                             <p id="portfolio-content-hexgem"></p>
-                            <img src="https://i.imgur.com/ZfUgPO0.gif" id="portfolio-image-hexgem">
+                            <IMG SRC="https://i.imgur.com/ZfUgPO0.gif" id="portfolio-image-hexgem">
                         </div>
                     </div>
                 </div>
             </section>
-            <hr class="m-0">
+            <hr class="m-0" />
             <!-- Education-->
 <!--            <section class="resume-section" id="education">
                 <div class="resume-section-content">
@@ -289,7 +291,7 @@
             <section class="resume-section" id="skills">
                 <div class="resume-section-content">
                     <h2 class="mb-5" id="skills-heading">Skills</h2>
-                    <div class="subheading mb-3" id="programming-languages-subheading">Programming Languages &amp; Tools</div>
+                    <div class="subheading mb-3" id="programming-languages-subheading">Programming Languages & Tools</div>
                     <ul class="list-inline dev-icons">
                         <li class="list-inline-item">
                             <i class="devicon-csharp-plain"></i>
@@ -339,27 +341,31 @@
                     </ul>
                 </div>
             </section>
-            <hr class="m-0">
+            <hr class="m-0" />
             <!-- Interests-->
             <section class="resume-section" id="interests">
                 <div class="resume-section-content">
                     <h2 class="mb-5" id="interests-heading">Interests</h2>
-                    <p id="interests-paragraph-1">I'm a game developer first but I enjoy spending my time experiencing various story telling mediums such as games, TV shows, movies, and anime. I love being part of the ride involving great story telling and the feeling of having my jaw drop and just sitting in awe after the credits roll is one of the greatest pleasures I can have. Just being able to truly enjoy and be part of the moment is something I really value and hope I can integrate in my games.</p>
+                    <p id="interests-paragraph-1">I'm a game developer first but I enjoy spending my time experiencing various story telling mediums such as games, TV shows, movies, and anime.
+                        I love being part of the ride involving great story telling and the feeling of having my jaw drop and just sitting in awe after the credits roll is one of
+                        the greatest pleasures I can have. Just being able to truly enjoy and be part of the moment is something I really value and hope I can integrate in my games.</p>
                     <p class="mb-0" id="interests-paragraph-2">I also enjoy spending too much time on reddit and enjoy anything from cat pictures to the latest programming advancements or discussions on the implementation of a game feature.</p>
                 </div>
             </section>
-            <hr class="m-0">
+            <hr class="m-0" />
             <!-- Awards-->
             <section class="resume-section" id="extracurricular">
                 <div class="resume-section-content">
                     <h2 class="mb-5" id="extracurricular-heading">Extra Curriculars</h2>
-                    <p id="extracurricular-paragraph">I've always been interested in story telling and the passion people have. Whether it be creating a work of art that can only come together through the passion of everyone involved or people being involved in an intense esports scene, the passion and fun they had was always something that inspired me. It has been over 10 years ago since I've captured those moments but these documentaries are something I'm still proud of and feel inspired by on rewatches.</p>
+                    <p id="extracurricular-paragraph">I've always been interested in story telling and the passion people have. Whether it be creating a work of art that can only come together through the passion
+                        of everyone involved or people being involved in an intense esports scene, the passion and fun they had was always something that inspired me. It has been over
+                        10 years ago since I've captured those moments but these documentaries are something I'm still proud of and feel inspired by on rewatches.</p>
                     <br>
                     <ul id="documentary-list" class="fa-ul mb-0">
                         <li id="documentary-item-1">
-                            <iframe width="560" height="315" src="https://www.youtube.com/embed/7q60bf0XTaI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="" id="documentary-video-1"></iframe>
+                            <iframe width="560" height="315" src="https://www.youtube.com/embed/7q60bf0XTaI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen id="documentary-video-1"></iframe>
                             <br><br>
-                            <iframe width="560" height="315" src="https://www.youtube.com/embed/Tlw_9--RPkM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="" id="documentary-video-2"></iframe>
+                            <iframe width="560" height="315" src="https://www.youtube.com/embed/Tlw_9--RPkM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen id="documentary-video-2"></iframe>
                         </li>
                     </ul>
                 </div>
@@ -374,6 +380,5 @@
         <script src="/js/scripts.js"></script>
 		<!--Iconify-->
 		<script src="https://code.iconify.design/1/1.0.7/iconify.min.js"></script>
-    
-
-</body></html>
+    </body>
+</html>


### PR DESCRIPTION
## Summary
- add a build step that compiles localized HTML from the shared template and localization data
- generate a dedicated English index page along with a Korean version that lives under /kr
- update localization data and asset paths so both pages share the same resources without client-side language switching

## Testing
- npm run build:locales

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dc64391548329a1711aed16373958)